### PR TITLE
Add flag to suppress camera FPS output

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To run a multipoint acquisition without launching the GUI (headless mode), use
 python3 software/main_hcs.py --run-acquisition --base-path /path/to/output --experiment-id my_experiment [--coordinates coordinates.csv]
 ```
 This saves data without opening the GUI. Additional options are documented in [software/README.md](software/README.md).
+Use `--no-camera-fps` to suppress camera FPS messages in the terminal.
 #### Setting up and run Squid software on Windows
 See this [post](https://forum.squid-imaging.org/t/setting-up-the-software-on-a-windows-computer/77) on Cephla forum for Windows instructions.
 

--- a/software/main_hcs.py
+++ b/software/main_hcs.py
@@ -153,9 +153,17 @@ if __name__ == "__main__":
     parser.add_argument("--use-piezo", action="store_true", help="Use piezo for Z stacks")
     parser.add_argument("--autofocus", action="store_true", help="Enable contrast-based autofocus")
     parser.add_argument("--reflection-af", action="store_true", help="Enable reflection autofocus")
+    parser.add_argument(
+        "--no-camera-fps",
+        action="store_true",
+        help="Disable printing camera FPS to the terminal",
+    )
     args = parser.parse_args()
 
     log = squid.logging.get_logger("main_hcs")
+
+    if args.no_camera_fps:
+        control._def.PRINT_CAMERA_FPS = False
 
     if args.verbose:
         log.info("Turning on debug logging.")


### PR DESCRIPTION
## Summary
- add `--no-camera-fps` flag to disable printing real-time camera FPS
- document `--no-camera-fps` in README

## Testing
- `python software/main_hcs.py --help` *(fails: ModuleNotFoundError: No module named 'qtpy')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'serial')*

------
https://chatgpt.com/codex/tasks/task_e_68bd948bbafc8329a64abed4dfa93004